### PR TITLE
アンケートの選択肢を追加するAPIの仮実装

### DIFF
--- a/docs/oas.yaml
+++ b/docs/oas.yaml
@@ -113,6 +113,8 @@ paths:
                 title:
                   type: string
                   example: Excel VBA
+                  minimum: 1
+                  maxLength: 50
       responses:
         '200':
           description: 正常系

--- a/iac/lib/vtl-templates/put-choice-request.vtl
+++ b/iac/lib/vtl-templates/put-choice-request.vtl
@@ -1,0 +1,11 @@
+#set($inputRoot = $input.path('$'))
+{
+    "TableName":"odyssey-osaka-questionnaires",
+    "Item":{
+        "id":{"N": "$method.request.path.questionnaireId"},
+        "sk":{"S": "QUESTIONNAIRE#CHOICE#$inputRoot.title"},
+        "choiceName": {"S": "$inputRoot.title"},
+        "questionnaireId": {"N": "$method.request.path.questionnaireId"}
+    },
+    "ReturnValues": "ALL_OLD"
+}


### PR DESCRIPTION
以下はLambda使わないと無理なので未対応です

- パスパラメータで存在しないIDを指定した時に404を返す
- パスパラメータに数字以外の文字列を指定した時に404を返す
    - 今はDynamoDBのPutItemが失敗しつつも200OKが返却されます 


まずは正常系だけ動くようにしてから時間との相談でLambda実装します