### PR TITLE
セッション検索チャット用APIのCORSでヘッダーの許可を追加

### DIFF
--- a/gen-ai-server/handler.py
+++ b/gen-ai-server/handler.py
@@ -1,4 +1,3 @@
-import base64
 import json
 import logging
 from typing import Any
@@ -11,7 +10,8 @@ logger = logging.getLogger()
 
 def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
     try:
-        body = json.loads(base64.b64decode(event["body"]).decode("utf-8"))
+        logger.info(event)
+        body = json.loads(event["body"])
         message = body.get("message", "")
 
         if not message:
@@ -21,7 +21,7 @@ def handler(event: dict[str, Any], _context: Any) -> dict[str, Any]:
             }
 
         llm_response = qa.run(message)
-        print(f"llm_response: {llm_response}")
+        logger.info(f"llm_response: {llm_response}")
 
         # レスポンスを作成
         response = {

--- a/iac/lib/constructs/gen-ai-api.ts
+++ b/iac/lib/constructs/gen-ai-api.ts
@@ -143,6 +143,7 @@ export class GenAiApiConstruct extends Construct {
       cors: {
         allowedMethods: [cdk.aws_lambda.HttpMethod.ALL],
         allowedOrigins: ["*"],
+        allowedHeaders: ["*"],
       },
     });
 


### PR DESCRIPTION
## やったこと
SSIA

## 動作確認

ブラウザからAPIが叩けること
<img width="1607" alt="image" src="https://github.com/cm-nishida-masayuki/odyssey-osaka-cx/assets/57205666/148c2011-c443-4492-bc97-15af32465c34">
