### PR TITLE
[Web] アンケート回答画面の作成

### DIFF
--- a/web/src/hooks/useQuestionnaireAnswers.tsx
+++ b/web/src/hooks/useQuestionnaireAnswers.tsx
@@ -1,6 +1,6 @@
+import axios from "axios";
 import useSWR, { useSWRConfig } from "swr";
 import { config } from "../config";
-import axios from "axios";
 import { useLocalStore } from "./useLocalStore";
 
 const fetcher = (key: string) => fetch(key).then((res) => res.json());
@@ -29,25 +29,13 @@ export const useQuestionnaireAnswers = ({
   const ANSWER_KEY = `${config.API_URL}/questionnaires/${questionnaireId}/answers`;
   const { data, error, isLoading } = useSWR<Answers>(ANSWER_KEY, fetcher);
 
-  const handlePostAnswer = async (
-    answer:
-      | {
-          AnswerType: "choice";
-          choice: string;
-        }
-      | {
-          AnswerType: "free";
-          content: string;
-        }
-  ) => {
-    const { AnswerType: _, ...props } = answer;
-
+  const handlePostAnswer = async ({ choice }: { choice: string }) => {
     await axios.post(
       `${config.API_URL}/questionnaires/${questionnaireId}/answers`,
       {
         participantId,
         participantName,
-        ...props,
+        choice,
       }
     );
   };

--- a/web/src/hooks/useQuestionnaires.tsx
+++ b/web/src/hooks/useQuestionnaires.tsx
@@ -1,4 +1,4 @@
-import useSWR from "swr";
+import useSWR, { useSWRConfig } from "swr";
 import { config } from "../config";
 
 const fetcher = (key: string) => fetch(key).then((res) => res.json());
@@ -6,9 +6,8 @@ const fetcher = (key: string) => fetch(key).then((res) => res.json());
 export type Questionnaire = {
   id: number;
   title: string;
-  content: string;
   type: string;
-  choices?: string[];
+  choices: string[];
 };
 
 export type Questionnaires = {
@@ -16,10 +15,16 @@ export type Questionnaires = {
 };
 
 export const useQuestionnaires = () => {
+  const { mutate } = useSWRConfig();
+  const ANSWER_KEY = `${config.API_URL}/questionnaires`;
   const { data, error, isLoading } = useSWR<Questionnaires>(
-    `${config.API_URL}/questionnaires`,
+    ANSWER_KEY,
     fetcher
   );
+
+  const clearCache = async () => {
+    await mutate(ANSWER_KEY);
+  };
 
   return [
     {
@@ -27,6 +32,8 @@ export const useQuestionnaires = () => {
       isLoading,
       error,
     },
-    {},
+    {
+      clearCache,
+    },
   ] as const;
 };

--- a/web/src/pages/QuestionnaireListPage.tsx
+++ b/web/src/pages/QuestionnaireListPage.tsx
@@ -16,10 +16,7 @@ export const QuestionnaireListPage = () => {
   return (
     <Box padding={"24px"} display="flex" flexDirection="column" gap="12px">
       {data.questionnaires.map((questionnaire) => (
-        <QuestionnaireList
-          key={questionnaire.questionnaireId}
-          {...questionnaire}
-        />
+        <QuestionnaireList key={questionnaire.id} {...questionnaire} />
       ))}
     </Box>
   );

--- a/web/src/pages/QuestionnairePage.tsx
+++ b/web/src/pages/QuestionnairePage.tsx
@@ -1,12 +1,13 @@
 import { Box, Button, Snackbar } from "@mui/material";
 import React, { useMemo, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { AddChoiceModal } from "../components/AddChoiceModal";
 import Loading from "../components/Loading";
 import { useQuestionnaireAnswers } from "../hooks/useQuestionnaireAnswers";
 import { useQuestionnaires } from "../hooks/useQuestionnaires";
 
 export const QuestionnairePage: React.FC = () => {
+  const navigate = useNavigate();
   const [selectedOption, setSelectedOption] = useState<string>("");
   const [isDisplayAddChoiceModal, setIsDisplayAddChoiceModal] =
     useState<boolean>(false);
@@ -51,6 +52,7 @@ export const QuestionnairePage: React.FC = () => {
       return;
     }
     await handlePostAnswer({ choice: selectedOption });
+    navigate(`/questionnaire/${questionnaireId}/answer`);
   };
 
   const handleClose = (_: React.SyntheticEvent | Event, reason?: string) => {
@@ -138,7 +140,7 @@ export const QuestionnairePage: React.FC = () => {
       >
         <Box display="flex" justifyContent="flex-end" marginBottom="8px">
           <Link
-            to=""
+            to={`/questionnaire/${questionnaireId}/answer`}
             style={{
               marginRight: "8px",
               color: "#5C5B64",

--- a/web/src/pages/QuestionnairePage.tsx
+++ b/web/src/pages/QuestionnairePage.tsx
@@ -1,35 +1,73 @@
-import { Box, Button } from "@mui/material";
-import React, { useState } from "react";
+import { Box, Button, Snackbar } from "@mui/material";
+import React, { useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { AddChoiceModal } from "../components/AddChoiceModal";
+import Loading from "../components/Loading";
 import { useQuestionnaireAnswers } from "../hooks/useQuestionnaireAnswers";
-
-type Option = "GraphQL" | "RestAPI";
+import { useQuestionnaires } from "../hooks/useQuestionnaires";
 
 export const QuestionnairePage: React.FC = () => {
-  const options: Option[] = ["GraphQL", "RestAPI"];
-  const [selectedOption, setSelectedOption] = useState<Option | null>(null);
-
-  const handleOptionClick = (option: Option): void => {
-    setSelectedOption(option);
-  };
-
+  const [selectedOption, setSelectedOption] = useState<string>("");
+  const [isDisplayAddChoiceModal, setIsDisplayAddChoiceModal] =
+    useState<boolean>(false);
+  const [isOpenSnackbar, setIsOpenSnackbar] = useState<boolean>(false);
   const { id: questionnaireId } = useParams();
   if (questionnaireId === undefined) {
     throw new Error("idが未入力になっています");
   }
 
-  const [isDisplayAddChoiceModal, setIsDisplayAddChoiceModal] =
-    useState<boolean>(false);
-
-  const [_, { handlePutChoices }] = useQuestionnaireAnswers({
+  const [{ data: questionnairesData, error, isLoading }, { clearCache }] =
+    useQuestionnaires();
+  const [_, { handlePutChoices, handlePostAnswer }] = useQuestionnaireAnswers({
     questionnaireId: parseInt(questionnaireId, 10),
   });
 
+  const questionnaire = useMemo(() => {
+    if (questionnairesData == null) return;
+    const questionnaire = questionnairesData.questionnaires.find(
+      (item) => item.id === parseInt(questionnaireId, 10)
+    );
+
+    if (questionnaire == null) {
+      throw new Error("対象のアンケートが見つかりません");
+    }
+    return questionnaire;
+  }, [questionnairesData, questionnaireId]);
+
+  const handleOptionClick = (option: string): void => {
+    setSelectedOption(option);
+  };
+
   const onAddChoice = async (choice: string) => {
     await handlePutChoices({ title: choice });
+    setSelectedOption(choice); //選択肢を追加したら、それを選択する
+    clearCache(); //キャッシュを破棄
     setIsDisplayAddChoiceModal(false);
   };
+
+  const handleAnswer = async () => {
+    if (selectedOption === "") {
+      setIsOpenSnackbar(true); //ユーザーに選択肢を選択するように促す
+      return;
+    }
+    await handlePostAnswer({ choice: selectedOption });
+  };
+
+  const handleClose = (_: React.SyntheticEvent | Event, reason?: string) => {
+    if (reason === "clickaway") return;
+    setIsOpenSnackbar(false);
+  };
+
+  if (
+    isLoading ||
+    questionnairesData === undefined ||
+    questionnaire === undefined
+  ) {
+    return <Loading />;
+  }
+  if (error) {
+    return <div>Error...</div>;
+  }
 
   return (
     <Box padding={"24px"}>
@@ -41,51 +79,53 @@ export const QuestionnairePage: React.FC = () => {
           fontWeight: "bold",
         }}
       >
-        GraphQL vs RestAPI
+        {questionnaire.title}
       </h2>
 
-      {options.map((option) => (
-        <Box
-          key={option}
-          display={"flex"}
-          alignItems={"center"}
-          height={"48px"}
-          padding={"0 24px"}
-          marginBottom={"12px"}
-          border={
-            selectedOption === option
-              ? "solid 2px #6BAD65"
-              : "solid 0.5px #212121"
-          }
-          borderRadius={"24px"}
-          bgcolor={selectedOption === option ? "#E7FFE5" : "transparent"}
-          onClick={() => handleOptionClick(option)}
-          style={{ cursor: "pointer" }}
-        >
-          <p
-            style={{
-              color: "#5C5B64",
-              fontSize: "16px",
-              fontWeight: "bold",
-            }}
+      <Box marginBottom={"100px"}>
+        {questionnaire.choices.map((option) => (
+          <Box
+            key={option}
+            display={"flex"}
+            alignItems={"center"}
+            height={"48px"}
+            padding={"0 24px"}
+            marginBottom={"12px"}
+            border={
+              selectedOption === option
+                ? "solid 2px #6BAD65"
+                : "solid 0.5px #212121"
+            }
+            borderRadius={"24px"}
+            bgcolor={selectedOption === option ? "#E7FFE5" : "transparent"}
+            onClick={() => handleOptionClick(option)}
+            style={{ cursor: "pointer" }}
           >
-            {option}
-          </p>
-        </Box>
-      ))}
+            <p
+              style={{
+                color: "#5C5B64",
+                fontSize: "16px",
+                fontWeight: "bold",
+              }}
+            >
+              {option}
+            </p>
+          </Box>
+        ))}
 
-      <Box
-        fontWeight={500}
-        style={{ fontSize: "14px" }}
-        display="flex"
-        alignItems="center"
-        justifyContent="center"
-        textAlign="center"
-        gap="8px"
-        onClick={() => setIsDisplayAddChoiceModal(true)}
-      >
-        <span style={{ fontSize: "24px", lineHeight: "32px" }}>+</span>
-        <span style={{ paddingTop: "3px" }}>選択肢を追加</span>
+        <Box
+          fontWeight={500}
+          style={{ fontSize: "14px" }}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+          textAlign="center"
+          gap="8px"
+          onClick={() => setIsDisplayAddChoiceModal(true)}
+        >
+          <span style={{ fontSize: "24px", lineHeight: "32px" }}>+</span>
+          <span style={{ paddingTop: "3px" }}>選択肢を追加</span>
+        </Box>
       </Box>
 
       <Box
@@ -121,6 +161,7 @@ export const QuestionnairePage: React.FC = () => {
             fontSize: "16px",
             fontWeight: "bold",
           }}
+          onClick={handleAnswer}
         >
           回答
         </Button>
@@ -131,6 +172,13 @@ export const QuestionnairePage: React.FC = () => {
           onClose={() => setIsDisplayAddChoiceModal(false)}
         />
       )}
+      <Snackbar
+        open={isOpenSnackbar}
+        autoHideDuration={3000}
+        onClose={handleClose}
+        message="選択肢を選択する必要があります"
+        anchorOrigin={{ vertical: "top", horizontal: "right" }}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
## やったこと

- idを元に表示するデータを選択
- 選択肢を追加した後に、選択肢を更新。また追加した選択肢を自動選択
- 回答 or 結果を見る を押した際の、結果画面への遷移
- 選択肢が選択されていない状態で、回答を押した場合の通知UI
  - このUIについては、改善の余地あり
- 選択肢が多すぎる場合に、選択肢の一部が回答のボタンと被る問題の修正

## スクリーンショット

| 画面1 | 画面2|
|--|--|
|<img width="360" alt="画面1" src="https://github.com/user-attachments/assets/e4e6a0aa-6514-46b8-ad61-848ac73a1f91">|<img width="352" alt="画面2" src="https://github.com/user-attachments/assets/cc9ada9f-a5de-42ad-a209-fa3489be47e7">|

| 選択肢を選択せずに、回答をクリック | 選択状態|
|--|--|
|<img width="355" alt="未選択" src="https://github.com/user-attachments/assets/b7616d93-b4b0-4a1b-b9f0-3455ac7aaf15">|<img width="355" alt="選択状態" src="https://github.com/user-attachments/assets/854dafb2-2bbc-4c40-94ed-e2fb81e8cfd0">|