### PR TITLE
アンケート結果画面を調整

### DIFF
--- a/web/src/components/QuestionnaireAnswer/QuestionnaireAnswerItem.tsx
+++ b/web/src/components/QuestionnaireAnswer/QuestionnaireAnswerItem.tsx
@@ -20,6 +20,7 @@ export const QuestionnaireAnswerItem = ({
       justifyContent={"space-between"}
       alignItems={"center"}
       height={"48px"}
+      width={"100%"}
       padding={"0 24px"}
       marginBottom={"12px"}
       border={"solid 0.5px #212121"}

--- a/web/src/components/QuestionnaireAnswer/QuestionnaireAnswerItem.tsx
+++ b/web/src/components/QuestionnaireAnswer/QuestionnaireAnswerItem.tsx
@@ -26,7 +26,6 @@ export const QuestionnaireAnswerItem = ({
       borderRadius={"24px"}
       bgcolor={"transparent"}
       style={{
-        cursor: "pointer",
         background: gradientStyle,
       }}
     >

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -1,4 +1,4 @@
 export const config = {
-  API_URL: "https://83nrjyi2r9.execute-api.ap-northeast-1.amazonaws.com/prod",
+  API_URL: "https://bl8g5n78kg.execute-api.ap-northeast-1.amazonaws.com/prod",
   WS_URL: "wss://88dy1lm8o8.execute-api.ap-northeast-1.amazonaws.com/dev/",
 };

--- a/web/src/hooks/useQuestionnaireEvent.tsx
+++ b/web/src/hooks/useQuestionnaireEvent.tsx
@@ -20,10 +20,17 @@ export const useQuestionnaireEvent = ({ questionnaireId }: Params) => {
     };
 
     ws.current.onmessage = (event) => {
-      const inData = JSON.parse(event.data) as Answers;
-      console.log(event);
+      const inComingAnswers = JSON.parse(event.data) as Answers;
 
-      setData(inData);
+      setData((prev) => {
+        if (prev == null) {
+          return inComingAnswers;
+        }
+
+        return {
+          answers: [...prev.answers, ...inComingAnswers.answers],
+        };
+      });
     };
 
     ws.current.onclose = () => {

--- a/web/src/hooks/useQuestionnaireEvent.tsx
+++ b/web/src/hooks/useQuestionnaireEvent.tsx
@@ -15,7 +15,11 @@ export const useQuestionnaireEvent = ({ questionnaireId }: Params) => {
 
     ws.current.onopen = () => {
       ws.current?.send(
-        JSON.stringify({ id: questionnaireId, type: "QUESTIONNAIRE" })
+        JSON.stringify({
+          action: "hello",
+          id: parseInt(questionnaireId),
+          type: "QUESTIONNAIRE",
+        })
       );
       console.log("WebSocket connected");
     };

--- a/web/src/pages/QuestionnaireAnswerPage.tsx
+++ b/web/src/pages/QuestionnaireAnswerPage.tsx
@@ -1,32 +1,22 @@
-import { Box, Container, Grid } from "@mui/material";
+import { Container, Grid } from "@mui/material";
 import { PieChart } from "@mui/x-charts";
-import {
-  Answers,
-  useQuestionnaireAnswers,
-} from "../hooks/useQuestionnaireAnswers";
-import { useMemo, useState } from "react";
-import { useQuestionnaireEvent } from "../hooks/useQuestionnaireEvent";
+import { useMemo } from "react";
 import { QuestionnaireAnswerItem } from "../components/QuestionnaireAnswer/QuestionnaireAnswerItem";
+import { useQuestionnaireAnswers } from "../hooks/useQuestionnaireAnswers";
+import { useQuestionnaireEvent } from "../hooks/useQuestionnaireEvent";
 
 export const QuestionnaireAnswerPage = () => {
   const [{ data }] = useQuestionnaireAnswers({ questionnaireId: 1 });
   const { data: newData } = useQuestionnaireEvent({ questionnaireId: "1" });
-  const [answers, setAnswers] = useState<Answers | undefined>(data);
 
   const choiceCounts = useMemo(() => {
-    if (answers == null && data == null) {
+    if (data == null) {
       return null;
     }
 
-    if (answers == null && data != null) {
-      return setAnswers(data);
-    }
+    const allAnswers = [...data.answers, ...(newData?.answers || [])];
 
-    const allAnswers = [...answers!.answers, ...(newData?.answers || [])];
-
-    setAnswers({ answers: allAnswers });
-
-    return answers?.answers.reduce(
+    return allAnswers.reduce(
       (acc, curr) => {
         acc[curr.choice] = (acc[curr.choice] || 0) + 1;
         return acc;

--- a/web/src/pages/QuestionnaireAnswerPage.tsx
+++ b/web/src/pages/QuestionnaireAnswerPage.tsx
@@ -1,4 +1,3 @@
-import { Box, Button, Container, Grid } from "@mui/material";
 import { PieChart } from "@mui/x-charts";
 import { useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -10,6 +9,24 @@ import { useQuestionnaires } from "../hooks/useQuestionnaires";
 export const QuestionnaireAnswerPage = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+
+  const colors = [
+    "#FF6384",
+    "#36A2EB",
+    "#FFCE56",
+    "#4BC0C0",
+    "#9966FF",
+    "#FF9F40",
+    "#FF5A5E",
+    "#5AD3D1",
+    "#A8E6CF",
+    "#FFD3B6",
+    "#FF8A80",
+    "#82B1FF",
+    "#B39DDB",
+    "#FFCC80",
+    "#81C784",
+  ];
 
   const [{ data }] = useQuestionnaireAnswers({
     questionnaireId: parseInt(id!),
@@ -59,10 +76,12 @@ export const QuestionnaireAnswerPage = () => {
       return null;
     }
 
-    return Object.entries(choiceCounts).map(([key, value]) => ({
-      value,
-      label: key,
-    }));
+    return Object.entries(choiceCounts)
+      .map(([key, value]) => ({
+        value,
+        label: key,
+      }))
+      .sort((a, b) => b.value - a.value);
   }, [choiceCounts]);
 
   const handleAnswer = () => {
@@ -70,12 +89,12 @@ export const QuestionnaireAnswerPage = () => {
   };
 
   return (
-    <Container>
-      <Grid container spacing={2} mb={10}>
-        <Grid item xs={12}>
+    <div style={{ maxWidth: "1200px", margin: "0 auto", padding: "0 16px" }}>
+      <div style={{ display: "grid", gap: "8px", marginBottom: "80px" }}>
+        <div>
           <h2
             style={{
-              margin: "0 0 24px 0",
+              margin: "0",
               color: "#5C5B64",
               fontSize: "20px",
               fontWeight: "bold",
@@ -83,71 +102,132 @@ export const QuestionnaireAnswerPage = () => {
           >
             {questionnaire?.title}
           </h2>
-        </Grid>
-        <Grid item>
+        </div>
+        <div>
           {graphData ? (
-            <PieChart
-              series={[
-                {
-                  arcLabel: "label",
-                  data: graphData!,
-                  arcLabelMinAngle: 25,
-                  arcLabelRadius: 60,
-                },
-              ]}
-              slotProps={{
-                legend: {
-                  hidden: true,
-                },
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                width: "100%",
               }}
-              width={400}
-              height={200}
-            />
+            >
+              <PieChart
+                colors={colors}
+                series={[
+                  {
+                    data: graphData,
+                    innerRadius: 0,
+                    outerRadius: 120,
+                    cx: 138,
+                    cy: 138,
+                  },
+                ]}
+                width={288}
+                height={288}
+                slotProps={{
+                  legend: {
+                    hidden: true,
+                  },
+                }}
+              />
+              <CustomLabel data={graphData} colors={colors} />
+            </div>
           ) : (
             <p>Loading...</p>
           )}
-        </Grid>
-        <Grid item xs={12}>
+        </div>
+        <div>
           {choiceCounts ? (
-            Object.entries(choiceCounts).map(([key, value]) => (
-              <Grid key={key}>
-                <QuestionnaireAnswerItem
-                  choice={key}
-                  count={value}
-                  allCount={choiceTotal}
-                />
-              </Grid>
-            ))
+            Object.entries(choiceCounts)
+              .sort(([, a], [, b]) => b - a)
+              .map(([key, value]) => (
+                <div
+                  style={{
+                    width: "100%",
+                  }}
+                  key={key}
+                >
+                  <QuestionnaireAnswerItem
+                    choice={key}
+                    count={value}
+                    allCount={choiceTotal}
+                  />
+                </div>
+              ))
           ) : (
             <p>Loading...</p>
           )}
-        </Grid>
-      </Grid>
-      <Box
-        position="fixed"
-        bottom={0}
-        left={0}
-        right={0}
-        padding="16px"
-        bgcolor="#F5F5F5"
+        </div>
+      </div>
+      <div
+        style={{
+          position: "fixed",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          padding: "16px",
+          backgroundColor: "#F5F5F5",
+        }}
       >
-        <Button
-          variant="contained"
-          fullWidth
+        <button
           style={{
+            width: "100%",
             height: "48px",
             backgroundColor: "black",
             color: "white",
             borderRadius: "9999px",
-            textTransform: "none",
+            border: "none",
             fontSize: "16px",
             fontWeight: "bold",
+            cursor: "pointer",
           }}
           onClick={handleAnswer}
         >
           回答
-        </Button>
-      </Box>
-    </Container>
+        </button>
+      </div>
+    </div>
   );
 };
+
+interface CustomLabelProps {
+  data: Array<{ label: string; value: number }>;
+  colors: string[];
+}
+
+const CustomLabel: React.FC<CustomLabelProps> = ({ data, colors }) => (
+  <div
+    style={{
+      display: "flex",
+      flexWrap: "wrap",
+      justifyContent: "flex-start",
+      margin: "12px 16px",
+      fontSize: "14px",
+    }}
+  >
+    {data.map((item, index) => (
+      <div
+        key={index}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          margin: "0 12px 4px 0",
+        }}
+      >
+        <div
+          style={{
+            width: 10,
+            height: 10,
+            backgroundColor: colors[index % colors.length],
+            marginRight: 8,
+          }}
+        />
+        <div>
+          {item.label}: {item.value}
+        </div>
+      </div>
+    ))}
+  </div>
+);

--- a/web/src/pages/QuestionnaireAnswerPage.tsx
+++ b/web/src/pages/QuestionnaireAnswerPage.tsx
@@ -10,7 +10,6 @@ import { useQuestionnaires } from "../hooks/useQuestionnaires";
 export const QuestionnaireAnswerPage = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { id: questionnaireId } = useParams();
 
   const [{ data }] = useQuestionnaireAnswers({
     questionnaireId: parseInt(id!),
@@ -67,7 +66,7 @@ export const QuestionnaireAnswerPage = () => {
   }, [choiceCounts]);
 
   const handleAnswer = () => {
-    navigate(`/questionnaire/${questionnaireId}`);
+    navigate(`/questionnaire/${id}`);
   };
 
   return (

--- a/web/src/pages/QuestionnaireAnswerPage.tsx
+++ b/web/src/pages/QuestionnaireAnswerPage.tsx
@@ -1,7 +1,7 @@
-import { Container, Grid } from "@mui/material";
+import { Box, Button, Container, Grid } from "@mui/material";
 import { PieChart } from "@mui/x-charts";
 import { useMemo } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { QuestionnaireAnswerItem } from "../components/QuestionnaireAnswer/QuestionnaireAnswerItem";
 import { useQuestionnaireAnswers } from "../hooks/useQuestionnaireAnswers";
 import { useQuestionnaireEvent } from "../hooks/useQuestionnaireEvent";
@@ -9,6 +9,8 @@ import { useQuestionnaires } from "../hooks/useQuestionnaires";
 
 export const QuestionnaireAnswerPage = () => {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { id: questionnaireId } = useParams();
 
   const [{ data }] = useQuestionnaireAnswers({
     questionnaireId: parseInt(id!),
@@ -64,9 +66,13 @@ export const QuestionnaireAnswerPage = () => {
     }));
   }, [choiceCounts]);
 
+  const handleAnswer = () => {
+    navigate(`/questionnaire/${questionnaireId}`);
+  };
+
   return (
     <Container>
-      <Grid container spacing={2}>
+      <Grid container spacing={2} mb={10}>
         <Grid item xs={12}>
           <h2
             style={{
@@ -116,6 +122,31 @@ export const QuestionnaireAnswerPage = () => {
           )}
         </Grid>
       </Grid>
+      <Box
+        position="fixed"
+        bottom={0}
+        left={0}
+        right={0}
+        padding="16px"
+        bgcolor="#F5F5F5"
+      >
+        <Button
+          variant="contained"
+          fullWidth
+          style={{
+            height: "48px",
+            backgroundColor: "black",
+            color: "white",
+            borderRadius: "9999px",
+            textTransform: "none",
+            fontSize: "16px",
+            fontWeight: "bold",
+          }}
+          onClick={handleAnswer}
+        >
+          回答
+        </Button>
+      </Box>
     </Container>
   );
 };

--- a/web/src/pages/QuestionnaireAnswerPage.tsx
+++ b/web/src/pages/QuestionnaireAnswerPage.tsx
@@ -5,6 +5,7 @@ import { useParams } from "react-router-dom";
 import { QuestionnaireAnswerItem } from "../components/QuestionnaireAnswer/QuestionnaireAnswerItem";
 import { useQuestionnaireAnswers } from "../hooks/useQuestionnaireAnswers";
 import { useQuestionnaireEvent } from "../hooks/useQuestionnaireEvent";
+import { useQuestionnaires } from "../hooks/useQuestionnaires";
 
 export const QuestionnaireAnswerPage = () => {
   const { id } = useParams<{ id: string }>();
@@ -13,6 +14,20 @@ export const QuestionnaireAnswerPage = () => {
     questionnaireId: parseInt(id!),
   });
   const { data: newData } = useQuestionnaireEvent({ questionnaireId: id! });
+
+  const [{ data: questionnairesData }] = useQuestionnaires();
+
+  const questionnaire = useMemo(() => {
+    if (questionnairesData == null) return;
+    const questionnaire = questionnairesData.questionnaires.find(
+      (item) => item.id === parseInt(id!, 10)
+    );
+
+    if (questionnaire == null) {
+      throw new Error("対象のアンケートが見つかりません");
+    }
+    return questionnaire;
+  }, [questionnairesData, id]);
 
   const choiceCounts = useMemo(() => {
     if (data == null) {
@@ -61,7 +76,7 @@ export const QuestionnaireAnswerPage = () => {
               fontWeight: "bold",
             }}
           >
-            GraphQL vs RestAPI
+            {questionnaire?.title}
           </h2>
         </Grid>
         <Grid item>

--- a/web/src/pages/QuestionnaireAnswerPage.tsx
+++ b/web/src/pages/QuestionnaireAnswerPage.tsx
@@ -1,6 +1,7 @@
 import { Container, Grid } from "@mui/material";
 import { PieChart } from "@mui/x-charts";
 import { useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
 import { QuestionnaireAnswerItem } from "../components/QuestionnaireAnswer/QuestionnaireAnswerItem";
 import {
   Answers,
@@ -9,8 +10,12 @@ import {
 import { useQuestionnaireEvent } from "../hooks/useQuestionnaireEvent";
 
 export const QuestionnaireAnswerPage = () => {
-  const [{ data }] = useQuestionnaireAnswers({ questionnaireId: 1 });
-  const { data: newData } = useQuestionnaireEvent({ questionnaireId: "1" });
+  const { id } = useParams<{ id: string }>();
+
+  const [{ data }] = useQuestionnaireAnswers({
+    questionnaireId: parseInt(id!),
+  });
+  const { data: newData } = useQuestionnaireEvent({ questionnaireId: id! });
   const [answers, setAnswers] = useState<Answers | undefined>(data);
 
   const choiceCounts = useMemo(() => {
@@ -74,9 +79,15 @@ export const QuestionnaireAnswerPage = () => {
             <PieChart
               series={[
                 {
+                  arcLabel: "label",
                   data: graphData!,
                 },
               ]}
+              slotProps={{
+                legend: {
+                  hidden: true,
+                },
+              }}
               width={400}
               height={200}
             />

--- a/web/src/pages/QuestionnaireAnswerPage.tsx
+++ b/web/src/pages/QuestionnaireAnswerPage.tsx
@@ -91,6 +91,8 @@ export const QuestionnaireAnswerPage = () => {
                 {
                   arcLabel: "label",
                   data: graphData!,
+                  arcLabelMinAngle: 25,
+                  arcLabelRadius: 60,
                 },
               ]}
               slotProps={{


### PR DESCRIPTION
## WebSocket周りのリファクタとパラメーターの修正

- パラメーターの修正
- 追加で到達したデータをhooksの中で継ぎ足すように


## 回答画面への動線を追加
https://www.notion.so/f33ae3f5fdfd43c99475ae11fb4eb09a

<img width="490" alt="image" src="https://github.com/user-attachments/assets/bb5ac5d3-eaea-4201-8094-710441255e6e">

## 判例の修正

https://www.notion.so/f2346d9c00714a348f26c6e3fb3e4ea5?pm=c

判例のグラフを調整し上記のチケットの問題を少し緩和しました

- 判例が表示される角度の下限値を設定
- グラフ横の判例を非表示に(グラフ上の判例のみ)
- 判例の位置を少し外側に

<img width="382" alt="image" src="https://github.com/user-attachments/assets/f050e0f0-4c3d-459b-a688-6060a6861f11">
